### PR TITLE
v3.0.1 — fix deep type imports under nodenext

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ixo/impactxclient-sdk",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "One ixo client to rule them all, One ixo client to find, One ixo client to bring them all, and in impact bind them",
   "author": "Ixo <ixo>",
   "homepage": "https://github.com/ixofoundation/ixo-MultiClient-SDK#readme",
@@ -52,6 +52,9 @@
       "types": "./types/stargate_client/index.d.ts",
       "import": "./module/stargate_client/index.js",
       "require": "./main/stargate_client/index.js"
+    },
+    "./types/*.js": {
+      "types": "./types/*.d.ts"
     },
     "./types/*": {
       "types": "./types/*.d.ts"


### PR DESCRIPTION
Adds a `./types/*.js` exports pattern so legacy deep type imports like `@ixo/impactxclient-sdk/types/messages/iid.js` resolve under `moduleResolution: node16/nodenext` (they failed against v3.0.0's exports map; consumers on `bundler`/`node` resolution were unaffected). Verified with a nodenext scratch project against the packed package — both the legacy style and the new granular subpaths resolve.

Authored by: Michael Pretorius <michael@ixo.world>